### PR TITLE
Config Specification Validation Using Cuelang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Download Cue"
+          name: "Run Tests - Specification Validation"
           command: DBT_EXTERNAL_TABLES_CI_INSTALL_CUE=1 ./run_spec_test.sh
       - store_artifacts:
           path: ./logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,17 @@
 version: 2.1
 
 jobs:
-  
+  spec-validation:
+    docker:
+      - image: circleci/stretch
+    steps:
+      - checkout
+      - run:
+          name: "Download Cue"
+          command: DBT_EXTERNAL_TABLES_CI_INSTALL_CUE=1 ./run_spec_test.sh
+      - store_artifacts:
+          path: ./logs
+
   integration-redshift:
     docker:
       - image: circleci/python:3.6.3-stretch
@@ -47,6 +57,7 @@ workflows:
   version: 2
   test-all:
     jobs:
+      - spec-validation
       - integration-redshift
       - integration-snowflake
       - integration-databricks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   spec-validation:
     docker:
-      - image: circleci/stretch
+      - image: circleci/python:3.6.3-stretch
     steps:
       - checkout
       - run:

--- a/README.md
+++ b/README.md
@@ -1,162 +1,184 @@
-<!--
- Copyright 2018 The CUE Authors
+# External sources in dbt
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+* Source config extension for metadata about external file structure
+* Adapter macros to create external tables and refresh external table partitions
+* Snowflake-specific macros to create, backfill, and refresh snowpipes
 
-     http://www.apache.org/licenses/LICENSE-2.0
+## Syntax
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
-[![GoDoc](https://godoc.org/cuelang.org/go?status.svg)](https://godoc.org/cuelang.org/go)
-[![Github](https://github.com/cuelang/cue/workflows/Test/badge.svg)](https://github.com/cuelang/cue/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/cuelang/cue)](https://goreportcard.com/report/github.com/cuelang/cue)
-[![GolangCI](https://golangci.com/badges/github.com/cuelang/cue.svg)](https://golangci.com/r/github.com/cuelang/cue)
-[![Go 1.12+](https://img.shields.io/badge/go-1.12-9cf.svg)](https://golang.org/dl/)
-[![platforms](https://img.shields.io/badge/platforms-linux|windows|macos-inactive.svg)]()
+```bash
+# iterate through all source nodes, create if missing + refresh if appropriate
+$ dbt run-operation stage_external_sources
 
-
-# The CUE Data Constraint Language
-
-_Configure, Unify, Execute_
-
-CUE is an open source data constraint language which aims
-to simplify tasks involving defining and using data.
-
-It is a superset of JSON,
-allowing users familiar with JSON to get started quickly.
-
-
-### What is it for?
-
-You can use CUE to
-
-- define a detailed validation schema for your data (manually or automatically from data)
-- reduce boilerplate in your data (manually or automatically from schema)
-- extract a schema from code
-- generate type definitions and validation code
-- merge JSON in a principled way
-- define and run declarative scripts
-
-
-### How?
-
-CUE merges the notion of schema and data.
-The same CUE definition can simultaneously be used for validating data
-and act as a template to reduce boilerplate.
-Schema definition is enriched with fine-grained value definitions
-and default values.
-At the same time,
-data can be simplified by removing values implied by such detailed definitions.
-The merging of these two concepts enables
-many tasks to be handled in a principled way.
-
-
-Constraints provide a simple and well-defined, yet powerful, alternative
-to inheritance,
-a common source of complexity with configuration languages.
-
-
-### CUE Scripting
-
-The CUE scripting layer defines declarative scripting, expressed in CUE,
-on top of data.
-This solves three problems:
-working around the closedness of CUE definitions (we say CUE is hermetic),
-providing an easy way to share common scripts and workflows for using data,
-and giving CUE the knowledge of how data is used to optimize validation.
-
-There are many tools that interpret data or use a specialized language for
-a specific domain (Kustomize, Ksonnet).
-This solves dealing with data on one level, but the problem it solves may repeat
-itself at a higher level when integrating other systems in a workflow.
-CUE scripting is generic and allows users to define any workflow.
-
-
-### Tooling
-
-CUE is designed for automation.
-Some aspects of this are:
-
-- convert existing YAML and JSON
-- automatically simplify configurations
-- rich APIs designed for automated tooling
-- formatter
-- arbitrary-precision arithmetic
-- generate CUE templates from source code
-- generate source code from CUE definitions (TODO)
-
-
-### Download and Install
-
-#### Install using Homebrew
-
-Using [Homebrew](https://brew.sh), you can install using the CUE Homebrew tap:
-
-`brew install cuelang/tap/cue`
-
-#### Install From Source
-
-If you already have Go installed, the short version is:
-
-```
-go get -u cuelang.org/go/cmd/cue
+# iterate through all source nodes, create or replace + refresh if appropriate
+$ dbt run-operation stage_external_sources --vars 'ext_full_refresh: true'
 ```
 
-This will install the `cue` command line tool.
+![sample docs](etc/sample_docs.png)
 
-For more details see [Installing CUE](./doc/install.md).
+The macros assume that you have already created an external stage (Snowflake)
+or external schema (Redshift/Spectrum), and that you have permissions to select from it
+and create tables in it.
 
+The `stage_external_sources` macro accepts a similar node selection syntax to
+[snapshotting source freshness](https://docs.getdbt.com/docs/running-a-dbt-project/command-line-interface/source/#specifying-sources-to-snapshot).
 
-### Learning CUE
+```bash
+# Stage all Snowplow and Logs external sources:
+$ dbt run-operation stage_external_sources --args 'select: snowplow logs'
 
-The fastest way to learn the basics is to follow the
-[tutorial on basic language constructs](./doc/tutorial/basics/Readme.md).
+# Stage a particular external source table:
+$ dbt run-operation stage_external_sources --args 'select: snowplow.event'
+```
 
-A more elaborate tutorial demonstrating of how to convert and restructure
-an existing set of Kubernetes configurations is available in
-[written form](./doc/tutorial/kubernetes/README.md).
+Maybe someday:
+```bash
+$ dbt source stage-external
+$ dbt source stage-external --full-refresh
+$ dbt source stage-external --select snowplow.event logs
+```
 
-### References
+## Spec
 
-- [Language Specification](./doc/ref/spec.md): official CUE Language specification.
-
-- [API](https://godoc.org/cuelang.org/go/cue): the API on godoc.org
-
-- [Builtin packages](https://godoc.org/cuelang.org/go/pkg): builtins available from CUE programs
-
-- [`cue` Command line reference](./doc/cmd/cue.md): the `cue` command
-
-
-### Contributing
-
-Our canonical Git repository is located at https://cue.googlesource.com.
-
-To contribute, please read the [Contribution Guide](./doc/contribute.md).
-
-To report issues or make a feature request, use the
-[issue tracker](https://github.com/cuelang/cue/issues).
-
-Changes can be contributed using Gerrit or Github pull requests.
+CUE is used to model and validate the specification. The full specification is available in [spec.cue](./spec.cue).
+CUE is a popular validation library used for validating configuration files in 
+open source projects such as [Kubernetes](https://cuelang.org/docs/integrations/k8s/).
 
 
-### Contact
+Use CUE to validate your dbt-external-table source configuration:
 
-You can get in touch with the cuelang community in the following ways:
+- [Install CUE](https://cuelang.org/docs/install/)
+- Clone dbt-external-tables
+- Validate your config using the CUE cli:
 
-- Chat with us on our
-  [Slack workspace](https://join.slack.com/t/cuelang/shared_invite/enQtNzQwODc3NzYzNTA0LTAxNWQwZGU2YWFiOWFiOWQ4MjVjNGQ2ZTNlMmIxODc4MDVjMDg5YmIyOTMyMjQ2MTkzMTU5ZjA1OGE0OGE1NmE).
+```
+$ cue vet path/to/your/source/config.yml path/to/ddbt-external-tables/repo/spec.cue
+```
+
+**Why use CUE?**
+
+Suppose you have the following dbt-external-table source configuration:
+
+```
+# integration_tests/ci/spec/invalid_column_description.yml
+
+version: 2
+
+sources:
+  - name: snowplow
+    database: analytics
+    schema: snowplow_external
+    loader: S3
+    loaded_at_field: collector_tstamp
+
+    tables:
+      - name: event
+        external:
+          location: "s3://snowplow/output"
+          row_format: "serde 'org.openx.data.jsonserde.JsonSerDe'
+            with serdeproperties (
+                'strip.outer.array'='false'
+            )"
+        columns:
+          - name: app_id
+            data_type: varchar(255)
+            descripion: "Application ID"
+```
+
+Do you see the issue? There is a type-o in `description`. Since CUE encodes the 
+external table specification, it's able to validate your config before you begin executing
+dbt-external-tables:
+
+```
+$ cue vet integration_tests/ci/spec/invalid_column_description.yml spec.cue
+sources.0.tables.0.columns.0: field `descripion` not allowed:
+    ./integration_tests/ci/spec/invalid_column_description.yml:19:14
+    ./spec.cue:39:1
+    ./spec.cue:39:10
+```
 
 
----
+```yml
+version: 2
 
-Unless otherwise noted, the CUE source files are distributed
-under the Apache 2.0 license found in the LICENSE file.
+sources:
+  - name: snowplow
+    tables:
+      - name: event
 
-This is not an officially supported Google product.
+                            # NEW: "external" property of source node
+        external:
+          location:         # S3 file path or Snowflake stage
+          file_format:      # Hive specification or Snowflake named format / specification
+          using:            # Hive specification
+          row_format:       # Hive specification
+          table_properties:   # Hive specification
+          options:          # Hive specification
+            header: 'TRUE'
 
+          # Snowflake: create an empty table + pipe instead of an external table
+          snowpipe:
+            auto_ingest:    true
+            aws_sns_topic:  # AWS
+            integration:    # Azure
+            copy_options:   "on_error = continue, enforce_length = false" # e.g.
+
+                            # Specify a list of file-path partitions.
+
+          # ------ SNOWFLAKE ------
+          partitions:
+            - name: collector_date
+              data_type: date
+              expression: to_date(substr(metadata$filename, 8, 10), 'YYYY/MM/DD')
+
+          # ------ REDSHIFT -------
+          partitions:
+            - name: appId
+              data_type: varchar(255)
+              vals:         # list of values
+                - dev
+                - prod
+              path_macro: dbt_external_tables.key_value
+                  # Macro to convert partition value to file path specification.
+                  # This "helper" macro is defined in the package, but you can use
+                  # any custom macro that takes keyword arguments 'name' + 'value'
+                  # and returns the path as a string
+
+                  # If multiple partitions, order matters for compiling S3 path
+            - name: collector_date
+              data_type: date
+              vals:         # macro w/ keyword args to generate list of values
+                macro: dbt.dates_in_range
+                args:
+                  start_date_str: '2019-08-01'
+                  end_date_str: '{{modules.datetime.date.today().strftime("%Y-%m-%d")}}'
+                  in_fmt: "%Y-%m-%d"
+                  out_fmt: "%Y-%m-%d"
+               path_macro: dbt_external_tables.year_month_day
+
+
+        # Specify ALL column names + datatypes. Column order matters for CSVs.
+        # Other file formats require column names to exactly match.
+
+        columns:
+          - name: app_id
+            data_type: varchar(255)
+            description: "Application ID"
+          - name: platform
+            data_type: varchar(255)
+            description: "Platform"
+        ...
+```
+
+## Resources
+
+* [`sample_sources`](sample_sources) for full valid YML config that establishes Snowplow events
+as a dbt source and stage-ready external table in Snowflake and Spectrum.
+* [`sample_analysis`](sample_analysis) for a "dry run" version of the DDL/DML that
+`stage_external_sources` will run as an operation
+
+## Supported databases
+
+* Redshift (Spectrum)
+* Snowflake
+* Spark

--- a/integration_tests/ci/spec/invalid_column_description.yml
+++ b/integration_tests/ci/spec/invalid_column_description.yml
@@ -1,0 +1,21 @@
+version: 2
+
+sources:
+  - name: snowplow
+    database: analytics
+    schema: snowplow_external
+    loader: S3
+    loaded_at_field: collector_tstamp
+
+    tables:
+      - name: event
+        external:
+          location: "s3://snowplow/output"
+          row_format: "serde 'org.openx.data.jsonserde.JsonSerDe'
+            with serdeproperties (
+                'strip.outer.array'='false'
+            )"
+        columns:
+          - name: app_id
+            data_type: varchar(255)
+            descripion: "Application ID"

--- a/run_spec_test.sh
+++ b/run_spec_test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ "$DBT_EXTERNAL_TABLES_CI_INSTALL_CUE" == "1" ]; then
+    wget https://github.com/cuelang/cue/releases/download/v0.2.2/cue_0.2.2_Linux_x86_64.tar.gz
+    tar xvfz cue_0.2.2_Linux_x86_64.tar.gz
+    cp cue /usr/local/bin
+fi
+
+cue vet sample_sources/spark.yml spec.cue
+cue vet sample_sources/redshift.yml spec.cue
+cue vet sample_sources/snowflake.yml spec.cue

--- a/run_spec_test.sh
+++ b/run_spec_test.sh
@@ -3,7 +3,7 @@
 if [ "$DBT_EXTERNAL_TABLES_CI_INSTALL_CUE" == "1" ]; then
     wget https://github.com/cuelang/cue/releases/download/v0.2.2/cue_0.2.2_Linux_x86_64.tar.gz
     tar xvfz cue_0.2.2_Linux_x86_64.tar.gz
-    cp cue /usr/local/bin
+    sudo cp cue /usr/local/bin
 fi
 
 cue vet sample_sources/spark.yml spec.cue

--- a/spec.cue
+++ b/spec.cue
@@ -1,0 +1,61 @@
+package spec
+
+version: 2
+sources: [...#Source]
+
+
+#StringInt: string | number
+
+#Partition: {
+	name:        string & !=""
+	data_type:   string & !=""
+	expression?: string
+	vals?: {
+		macro: string & !=""
+		args: [string]: #StringInt
+	}
+	path_macro?: string & !=""
+}
+
+#SourceSnowflake: {
+	location:     string & !=""
+	file_format:  string & !=""
+	auto_refresh: bool
+	partitions: [...#Partition]
+}
+
+#SourceRedshift: {
+	location:   string & !=""
+	row_format: string & !=""
+	partitions: [...#Partition]
+}
+
+#SourceSpark: {
+	location: string & !=""
+	using:    string & !=""
+	options: [string]: string
+}
+
+#Column: {
+	name:         string & !=""
+	data_type:    string & !=""
+	description?: string
+}
+
+#Table: {
+	name:     string & !=""
+	external: #SourceRedshift | #SourceSnowflake | #SourceSpark
+	table_properties: [string]: string
+	columns: [...#Column]
+}
+
+#Loaders: "S3"
+
+#Source: {
+	name:             string & !=""
+	database?:        string & !=""
+	schema?:          string & !=""
+	loader:           #Loaders
+	loaded_at_field?: string & !=""
+	tables: [...#Table]
+}


### PR DESCRIPTION
## Description & motivation

First off this package is amazing thank you for all your hard work. I was able to get started with this very easily and everything just worked. 

I used this package with redshift and some of my source definitions are really large (1000+ line yaml configs). During development we frequently run into issues with the config language. Editors are able to catch some yaml syntax but is unable to catch issues like the `external.partitions` being on the correct indentation level. 

In order to address this and shorten the validation feedback loop I created a specification using Cuelang. This specification enables validating any dbt-external-tables configuration. 


Suppose you have the following dbt-external-table source configuration:

```
# integration_tests/ci/spec/invalid_column_description.yml

version: 2

sources:
  - name: snowplow
    database: analytics
    schema: snowplow_external
    loader: S3
    loaded_at_field: collector_tstamp

    tables:
      - name: event
        external:
          location: "s3://snowplow/output"
          row_format: "serde 'org.openx.data.jsonserde.JsonSerDe'
            with serdeproperties (
                'strip.outer.array'='false'
            )"
        columns:
          - name: app_id
            data_type: varchar(255)
            descripion: "Application ID"
```

Do you see the issue? I sure didn't! There is a type-o in `description`. Since CUE encodes the 
external table specification, it's able to validate your config before you begin executing
dbt-external-tables:

```
$ cue vet integration_tests/ci/spec/invalid_column_description.yml spec.cue
sources.0.tables.0.columns.0: field `descripion` not allowed:
    ./integration_tests/ci/spec/invalid_column_description.yml:19:14
    ./spec.cue:39:1
    ./spec.cue:39:10
```

Would you be willing to accept this PR? I found that CUE made the configuration development process much easier.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
