### PR TITLE
Add support to append METADATA$FILENAME

### DIFF
--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -15,10 +15,16 @@
             {{partition.name}} {{partition.data_type}} as {{partition.expression}}{{- ',' if not loop.last or columns|length > 0 -}}
         {%- endfor -%}{%- endif -%}
         {%- for column in columns %}
-            {%- set column_quoted = adapter.quote(column.name) if column.quote else column.name %}
+            {%- set col_name -%}
+                {%- if is_csv and column.name == 'METADATA$FILENAME' -%}METADATA_FILENAME
+                {%- else -%}{{column.name}}
+                {%- endif -%}
+            {%- endset %}
+            {%- set column_quoted = adapter.quote(col_name) if column.quote else col_name %}
             {%- set col_expression -%}
-                {%- if is_csv -%}nullif(value:c{{loop.index}},''){# special case: get columns by ordinal position #}
-                {%- else -%}nullif(value:{{column.name}},''){# standard behavior: get columns by name #}
+                {%- if is_csv and col_name == 'METADATA_FILENAME' -%}{{column.name}}{# special case: add support to append external source file name. This must be the last column or it will break the ingest #}
+                {%- elif is_csv -%}nullif(value:c{{loop.index}},''){# special case: get columns by ordinal position #}
+                {%- else -%}nullif(value:{{col_name}},''){# standard behavior: get columns by name #}
                 {%- endif -%}
             {%- endset %}
             {{column_quoted}} {{column.data_type}} as ({{col_expression}}::{{column.data_type}})


### PR DESCRIPTION
## Description & motivation
<!---
Surfacing the source file for external tables is useful for data lineage, troubleshooting, and profiling. There was no easy way to surface the METADATA$FILENAME in the external tables package.

These changes are currently limited. They only affect CSV files and this only works when appending the METADATA$FILENAME at the end. Trying to insert this column elsewhere would throw off the counter that this method uses to track CSV columns.

Possible future improvements:
-Verify/add support for other file types and databases
-Make this a table-level boolean (i.e. append_filename: TRUE/FALSE) Second PR updates code to add table-level boolean to ensure placement of the METADATA$FILENAME column always works
-->

## Checklist
- [X] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added an integration test for my fix/feature (if applicable)
