### PR TITLE
Upgrade dbt v0.20, dbt-utils v0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # External sources in dbt
 
-dbt v0.15.0 [added support](https://github.com/fishtown-analytics/dbt/pull/1784) for an `external` property within `sources` that can include information about `location`, `partitions`, and other database-specific properties.
+dbt v0.15.0 [added support](https://github.com/dbt-labs/dbt/pull/1784) for an `external` property within `sources` that can include information about `location`, `partitions`, and other database-specific properties.
 
 This package provides:
 * Macros to create/replace external tables and refresh their partitions, using the metadata provided in your `.yml` file source definitions
@@ -19,7 +19,7 @@ This package provides:
 
 ## Installation
 
-Follow the instructions at [hub.getdbt.com](https://hub.getdbt.com/fishtown-analytics/dbt_external_tables/latest/) on how to modify your `packages.yml` and run `dbt deps`.
+Follow the instructions at [hub.getdbt.com](https://hub.getdbt.com/dbt-labs/dbt_external_tables/latest/) on how to modify your `packages.yml` and run `dbt deps`.
 
 ## Syntax
 
@@ -115,7 +115,7 @@ execute the appropriate `create`, `refresh`, and/or `drop` commands:
 `stage_external_sources` runs as an operation
 * [`tested specs`](integration_tests/models/plugins): source spec variations that are confirmed to work on each database, via integration tests
 
-If you encounter issues using this package or have questions, please check the [open issues](https://github.com/fishtown-analytics/dbt-external-tables/issues), as there's a chance it's a known limitation or work in progress. If not, you can:
+If you encounter issues using this package or have questions, please check the [open issues](https://github.com/dbt-labs/dbt-external-tables/issues), as there's a chance it's a known limitation or work in progress. If not, you can:
 - open a new issue to report a bug or suggest an enhancement
 - post a technical question to [StackOverflow](https://stackoverflow.com/questions/tagged/dbt)
 - post a conceptual question to the relevant database channel (#db-redshift, #dbt-snowflake, etc) in the [dbt Slack community](https://community.getdbt.com/)

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,9 +1,9 @@
 name: 'dbt_external_tables'
-version: '0.3.0'
+version: '0.7.0'
 
 config-version: 2
 
-require-dbt-version: ">=0.18.0"
+require-dbt-version: ">=0.20.0"
 
 source-paths: ["models"]
 analysis-paths: ["analysis"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -17,8 +17,9 @@ clean-targets:
     - "target"
     - "dbt_modules"
 
-vars:
-  dbt_external_tables_dispatch_list: ['dbt_external_tables_integration_tests']
+dispatch:
+  - macro_namespace: dbt_external_tables
+    search_order: ['dbt_external_tables_integration_tests', 'dbt_external_tables']
 
 seeds:
   +quote_columns: false

--- a/integration_tests/macros/common/prep_external.sql
+++ b/integration_tests/macros/common/prep_external.sql
@@ -1,5 +1,5 @@
 {% macro prep_external() %}
-    {{ return(adapter.dispatch('prep_external', dbt_external_tables._get_dbt_external_tables_namespaces())()) }}
+    {{ return(adapter.dispatch('prep_external', 'dbt_external_tables')()) }}
 {% endmacro %}
 
 {% macro default__prep_external() %}

--- a/macros/common/create_external_table.sql
+++ b/macros/common/create_external_table.sql
@@ -1,7 +1,5 @@
 {% macro create_external_table(source_node) %}
-    {{ adapter.dispatch('create_external_table', 
-        packages = dbt_external_tables._get_dbt_external_tables_namespaces()) 
-        (source_node) }}
+    {{ adapter.dispatch('create_external_table', 'dbt_external_tables')(source_node) }}
 {% endmacro %}
 
 {% macro default__create_external_table(source_node) %}

--- a/macros/common/get_external_build_plan.sql
+++ b/macros/common/get_external_build_plan.sql
@@ -1,7 +1,5 @@
 {% macro get_external_build_plan(source_node) %}
-    {{ return(adapter.dispatch('get_external_build_plan',
-        packages = dbt_external_tables._get_dbt_external_tables_namespaces())
-        (source_node)) }}
+    {{ return(adapter.dispatch('get_external_build_plan', 'dbt_external_tables')(source_node)) }}
 {% endmacro %}
 
 {% macro default__get_external_build_plan(source_node) %}

--- a/macros/common/helpers/dropif.sql
+++ b/macros/common/helpers/dropif.sql
@@ -1,7 +1,5 @@
 {% macro dropif(node) %}
-    {{ adapter.dispatch('dropif', 
-        packages = dbt_external_tables._get_dbt_external_tables_namespaces()) 
-        (node) }}
+    {{ adapter.dispatch('dropif', 'dbt_external_tables')(node) }}
 {% endmacro %}
 
 {% macro default__dropif() %}

--- a/macros/common/helpers/get_external_tables_namespace.sql
+++ b/macros/common/helpers/get_external_tables_namespace.sql
@@ -1,4 +1,0 @@
-{% macro _get_dbt_external_tables_namespaces() %}
-  {% set override_namespaces = var('dbt_external_tables_dispatch_list', []) %}
-  {% do return(override_namespaces + ['dbt_external_tables']) %}
-{% endmacro %}

--- a/macros/common/helpers/transaction.sql
+++ b/macros/common/helpers/transaction.sql
@@ -1,5 +1,5 @@
 {% macro exit_transaction() %}
-    {{ return(adapter.dispatch('exit_transaction', dbt_external_tables._get_dbt_external_tables_namespaces())()) }}
+    {{ return(adapter.dispatch('exit_transaction', 'dbt_external_tables')()) }}
 {% endmacro %}
 
 {% macro default__exit_transaction() %}

--- a/macros/common/refresh_external_table.sql
+++ b/macros/common/refresh_external_table.sql
@@ -1,7 +1,5 @@
 {% macro refresh_external_table(source_node) %}
-    {{ return(adapter.dispatch('refresh_external_table', 
-        packages = dbt_external_tables._get_dbt_external_tables_namespaces()) 
-        (source_node)) }}
+    {{ return(adapter.dispatch('refresh_external_table', 'dbt_external_tables')(source_node)) }}
 {% endmacro %}
 
 {% macro default__refresh_external_table(source_node) %}

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - package: fishtown-analytics/dbt_utils
-    version: [">=0.6.0", "<0.7.0"]
+  - package: dbt-labs/dbt_utils
+    version: [">=0.7.0", "<0.8.0"]

--- a/run_test.sh
+++ b/run_test.sh
@@ -9,14 +9,14 @@ if [[ ! -f $VENV ]]; then
     if [ $1 == 'databricks' ]
     then
         echo "Installing dbt-spark"
-        pip install dbt-spark[ODBC] --upgrade
+        pip install dbt-spark[ODBC] --upgrade --pre
     elif [ $1 == 'azuresql' ]
     then
         echo "Installing dbt-sqlserver"
-        pip install dbt-sqlserver --upgrade
+        pip install dbt-sqlserver --upgrade --pre
     else
         echo "Installing dbt-$1"
-        pip install dbt-$1 --upgrade
+        pip install dbt-$1 --upgrade --pre
     fi
 fi
 


### PR DESCRIPTION
## Description & motivation

Breaking changes to `dispatch` in dbt v0.20.0. Require dbt-utils v0.7.0 for the same reason.

For now, I just want to see what passes. I won't be able to merge this until v0.20 Spark and MSFT plugin RCs are live.

I'm going to swing around to the other open PRs, include what I can in a patch release (0.6.7), and then release this change as a new minor version (0.7.0).

## Checklist
- [x] I have verified that these changes work locally
- ~I have updated the README.md (if applicable)~
- ~I have added an integration test for my fix/feature (if applicable)~
