### PR TITLE
Updating external tables package

### DIFF
--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -30,5 +30,6 @@
     {% if external.auto_refresh -%} auto_refresh = {{external.auto_refresh}} {%- endif %}
     {% if external.pattern -%} pattern = '{{external.pattern}}' {%- endif %}
     {% if external.integration -%} integration = '{{external.integration}}' {%- endif %}
+    {% if external.refresh_on_create -%} refresh_on_create = {{external.refresh_on_create}} {%- endif %}
     file_format = {{external.file_format}}
 {% endmacro %}


### PR DESCRIPTION
## Description & motivation
<!---
The macro _snowflake__create_external_table_ does not include the option _refresh_on_create_. If you create a table without specifying _false_ for this option, Snowflake will attempt to refresh the table with files. If the size of the metadata for the files exceeds a certain limit, Snowflake will throw an error: https://community.snowflake.com/s/article/Create-External-table-failing-with-error-code-001057-0A000

The macro has been updated to include this option. 
-->

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added an integration test for my fix/feature (if applicable)
