### PR TITLE
Explicitly set auto_refresh if populated

### DIFF
--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -27,7 +27,7 @@
     {%- endif -%}
     {% if partitions %} partition by ({{partitions|map(attribute='name')|join(', ')}}) {% endif %}
     location = {{external.location}} {# stage #}
-    {% if external.auto_refresh -%} auto_refresh = {{external.auto_refresh}} {%- endif %}
+    {% if external.auto_refresh is not none -%} auto_refresh = {{external.auto_refresh}} {%- endif %}
     {% if external.pattern -%} pattern = '{{external.pattern}}' {%- endif %}
     {% if external.integration -%} integration = '{{external.integration}}' {%- endif %}
     file_format = {{external.file_format}}


### PR DESCRIPTION
If `auto_refresh` is set to false, we need to explicitly declare it -- do not include only if not included in the yml.  This will allow `auto_refresh` to be explicitly set as false for GCS integrations.

## Description & motivation
Change a check for `is true` (which prevents the config being written out when explicitly set as false) to `is not none`

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added an integration test for my fix/feature (if applicable)
