### PR TITLE
Add synapse installation condition in tests

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -14,6 +14,10 @@ if [[ ! -f $VENV ]]; then
     then
         echo "Installing dbt-sqlserver"
         pip install dbt-sqlserver --upgrade --pre
+    elif [ $1 == 'synapse' ]
+    then
+        echo "Installing dbt-synapse"
+        pip install dbt-synapse --upgrade --pre
     else
         echo "Installing dbt-$1"
         pip install dbt-$1 --upgrade --pre


### PR DESCRIPTION
## Description & motivation
`run_test.sh` did not include an installation option when run as `./run_test.sh synapse` which is called in the current circleci [config.yml](https://github.com/dbt-labs/dbt-external-tables/blob/master/.circleci/config.yml#L82) This appears to be the cause for the test failure in PR #103 

## Checklist
- [x] I have verified that these changes work locally
- [N/A] I have updated the README.md (if applicable)
- [N/A] I have added an integration test for my fix/feature (if applicable)
