### PR TITLE
deprecate the `synapse__` macros

### DIFF
--- a/integration_tests/macros/plugins/sqlserver/prep_external.sql
+++ b/integration_tests/macros/plugins/sqlserver/prep_external.sql
@@ -69,7 +69,3 @@
     {%- endif %}
 
 {% endmacro %}
-
-{% macro synapse__prep_external() %}
-    {% do return( dbt_external_tables_integration_tests.sqlserver__prep_external()) %}
-{% endmacro %}

--- a/macros/plugins/sqlserver/create_external_table.sql
+++ b/macros/plugins/sqlserver/create_external_table.sql
@@ -29,7 +29,3 @@
             {%- endfor -%}
     )
 {% endmacro %}
-
-{% macro synapse__create_external_table(source_node) %}
-    {% do return( dbt_external_tables.sqlserver__create_external_table(source_node)) %}
-{% endmacro %}

--- a/macros/plugins/sqlserver/get_external_build_plan.sql
+++ b/macros/plugins/sqlserver/get_external_build_plan.sql
@@ -21,7 +21,3 @@
     {% do return(build_plan) %}
 
 {% endmacro %}
-
-{% macro synapse__get_external_build_plan(source_node) %}
-    {% do return( dbt_external_tables.sqlserver__get_external_build_plan(source_node)) %}
-{% endmacro %}

--- a/macros/plugins/sqlserver/helpers/dropif.sql
+++ b/macros/plugins/sqlserver/helpers/dropif.sql
@@ -10,7 +10,3 @@
     {{return(ddl)}}
 
 {% endmacro %}
-
-{% macro synapse__dropif(node) %}
-    {% do return( dbt_external_tables.sqlserver__dropif(node)) %}
-{% endmacro %}


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added an integration test for my fix/feature (if applicable)
