### PR TITLE
Fix/spark create table macro

### DIFF
--- a/integration_tests/models/plugins/spark_external.yml
+++ b/integration_tests/models/plugins/spark_external.yml
@@ -37,7 +37,7 @@ sources:
           <<: *csv-people-using
           partitions: &parts-of-the-people
             - name: section
-              data_type: varchar
+              data_type: string
         columns: *cols-of-the-people
         tests: *equal-to-the-people
 

--- a/macros/plugins/spark/create_external_table.sql
+++ b/macros/plugins/spark/create_external_table.sql
@@ -2,7 +2,7 @@
 
     {%- set columns = source_node.columns.values() -%}
     {%- set external = source_node.external -%}
-    {%- set partitions = external.partition -%}
+    {%- set partitions = external.partitions -%}
     {%- set options = external.options -%}
 
 {# https://spark.apache.org/docs/latest/sql-data-sources-hive-tables.html #}

--- a/macros/plugins/spark/create_external_table.sql
+++ b/macros/plugins/spark/create_external_table.sql
@@ -13,7 +13,7 @@
             {{- ',' if not loop.last -}}
         {% endfor %}
     {% endif -%}
-    {% if partitions|length > 0 -%} 
+    {% if partitions -%} 
         {%- for partition in partitions -%}
             {{partition.name}} {{partition.data_type}}{{', ' if not loop.last}}
         {%- endfor -%}

--- a/macros/plugins/spark/create_external_table.sql
+++ b/macros/plugins/spark/create_external_table.sql
@@ -21,7 +21,7 @@
     ) {%- endif %}
     {% if partitions -%} partitioned by (
         {%- for partition in partitions -%}
-            {{partition.name}} {{partition.data_type}}{{', ' if not loop.last}}
+            {{partition.name}}{{', ' if not loop.last}}
         {%- endfor -%}
     ) {%- endif %}
     {% if external.row_format -%} row format {{external.row_format}} {%- endif %}

--- a/macros/plugins/spark/create_external_table.sql
+++ b/macros/plugins/spark/create_external_table.sql
@@ -10,7 +10,7 @@
     {%- if columns|length > 0 %} (
         {% for column in columns %}
             {{column.name}} {{column.data_type}}
-            {{- ',' if not loop.last -}}
+            {{- ',' if not loop.last or partitions is not none -}}
         {% endfor %}
     {% endif -%}
     {% if partitions -%} 

--- a/macros/plugins/spark/create_external_table.sql
+++ b/macros/plugins/spark/create_external_table.sql
@@ -24,7 +24,7 @@
             '{{ key }}' = '{{value}}' {{- ', \n' if not loop.last -}}
         {%- endfor -%}
     ) {%- endif %}
-    {% if partitions|length > 0 -%} partitioned by (
+    {% if partitions -%} partitioned by (
         {%- for partition in partitions -%}
             {{partition.name}}{{', ' if not loop.last}}
         {%- endfor -%}

--- a/macros/plugins/spark/create_external_table.sql
+++ b/macros/plugins/spark/create_external_table.sql
@@ -12,14 +12,19 @@
             {{column.name}} {{column.data_type}}
             {{- ',' if not loop.last -}}
         {% endfor %}
-    ) {% endif -%}
+    {% endif -%}
+    {% if partitions|length > 0 -%} 
+        {%- for partition in partitions -%}
+            {{partition.name}} {{partition.data_type}}{{', ' if not loop.last}}
+        {%- endfor -%}
+    ) {%- endif %}
     {% if external.using %} using {{external.using}} {%- endif %}
     {% if options -%} options (
         {%- for key, value in options.items() -%}
             '{{ key }}' = '{{value}}' {{- ', \n' if not loop.last -}}
         {%- endfor -%}
     ) {%- endif %}
-    {% if partitions -%} partitioned by (
+    {% if partitions|length > 0 -%} partitioned by (
         {%- for partition in partitions -%}
             {{partition.name}}{{', ' if not loop.last}}
         {%- endfor -%}

--- a/macros/plugins/spark/create_external_table.sql
+++ b/macros/plugins/spark/create_external_table.sql
@@ -12,14 +12,14 @@
             {{column.name}} {{column.data_type}}
             {{- ',' if not loop.last or partitions is not none -}}
         {% endfor %}
-    {% endif -%}
-    {% if partitions -%} 
-        {%- for partition in partitions -%}
-            {{partition.name}} {{partition.data_type}}{{', ' if not loop.last}}
-        {%- endfor -%}
-        )
-    {% else -%}
-        )
+        {% if partitions -%} 
+            {%- for partition in partitions -%}
+                {{partition.name}} {{partition.data_type}}{{', ' if not loop.last}}
+            {%- endfor -%}
+            )
+        {% else -%}
+            )
+        {%- endif %}
     {%- endif %}
     {% if external.using %} using {{external.using}} {%- endif %}
     {% if options -%} options (

--- a/macros/plugins/spark/create_external_table.sql
+++ b/macros/plugins/spark/create_external_table.sql
@@ -17,7 +17,10 @@
         {%- for partition in partitions -%}
             {{partition.name}} {{partition.data_type}}{{', ' if not loop.last}}
         {%- endfor -%}
-    ) {%- endif %}
+        )
+    {% else -%}
+        )
+    {%- endif %}
     {% if external.using %} using {{external.using}} {%- endif %}
     {% if options -%} options (
         {%- for key, value in options.items() -%}


### PR DESCRIPTION
## Description & motivation
Fixes #108. The spark__create_external_table macro had several bugs, including:

- Partitions were not picked up
- DDL statement for partitions was not spark compliant
- Tests also had bugs

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added an integration test for my fix/feature (if applicable)
