### PR TITLE
Fix BigQuery partitions by separating them using commas

### DIFF
--- a/macros/plugins/bigquery/create_external_table.sql
+++ b/macros/plugins/bigquery/create_external_table.sql
@@ -22,7 +22,7 @@
         {% if options and options.get('hive_partition_uri_prefix', none) %}
         with partition columns {%- if partitions %} (
             {%- for partition in partitions %}
-                {{partition.name}} {{partition.data_type}}
+                {{partition.name}} {{partition.data_type}}{{',' if not loop.last}}
             {%- endfor -%}
         ) {% endif -%}
         {% endif %}


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->
BigQuery external tables with multiple partition columns were failing due to missing comma separators between partition columns in the `CREATE EXTERNAL TABLE` statement.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added an integration test for my fix/feature (if applicable)
