### PR TITLE
[Spark] Fix partitions

### DIFF
--- a/integration_tests/models/plugins/spark/spark_external.yml
+++ b/integration_tests/models/plugins/spark/spark_external.yml
@@ -37,7 +37,7 @@ sources:
           <<: *csv-people-using
           partitions: &parts-of-the-people
             - name: section
-              data_type: varchar
+              data_type: string
         columns: *cols-of-the-people
         tests: *equal-to-the-people
 

--- a/macros/plugins/spark/create_external_table.sql
+++ b/macros/plugins/spark/create_external_table.sql
@@ -2,7 +2,7 @@
 
     {%- set columns = source_node.columns.values() -%}
     {%- set external = source_node.external -%}
-    {%- set partitions = external.partition -%}
+    {%- set partitions = external.partitions -%}
     {%- set options = external.options -%}
 
 {# https://spark.apache.org/docs/latest/sql-data-sources-hive-tables.html #}

--- a/macros/plugins/spark/get_external_build_plan.sql
+++ b/macros/plugins/spark/get_external_build_plan.sql
@@ -19,6 +19,13 @@
         {% set build_plan = build_plan + dbt_external_tables.refresh_external_table(source_node) %}
     {% endif %}
 
+    {% set recover_partitions = spark__recover_partitions(source_node) %}
+    {% if recover_partitions|length > 0 %}
+    {% set build_plan = build_plan + [
+        recover_partitions
+    ] %}
+    {% endif %}
+
     {% do return(build_plan) %}
 
 {% endmacro %}

--- a/macros/plugins/spark/helpers/recover_partitions.sql
+++ b/macros/plugins/spark/helpers/recover_partitions.sql
@@ -1,0 +1,12 @@
+{% macro spark__recover_partitions(source_node) %}
+    {# https://docs.databricks.com/sql/language-manual/sql-ref-syntax-ddl-alter-table.html #}
+
+    {% set ddl %}
+    {%- if source_node.external.partitions and source_node.external.using and source_node.external.using|lower != 'delta' -%}
+        ALTER TABLE {{ source(source_node.source_name, source_node.name) }} RECOVER PARTITIONS
+    {%- endif -%}
+    {% endset %}
+
+    {{return(ddl)}}
+
+{% endmacro %}


### PR DESCRIPTION
## Description & motivation

The partitions were not working properly.  Fixes #108 .

First, there was a typo, therefor the partition clause was not added. 

After doing some testing we learned that the [partitions should be recovered](https://docs.databricks.com/sql/language-manual/sql-ref-syntax-ddl-alter-table.html ) after creating the table. This is also needed for a non-full-refresh, because new partitions are only detected after running the `RECOVER PARTITIONS` command.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added an integration test for my fix/feature (if applicable)
