### PR TITLE
Fix for v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # dbt-external-tables v0.7.3
 
 ### Fixes
-- Hard code printer width for backwards compatibility with older versions of dbt Core
+- Hard code printer width for backwards compatibility with older versions of dbt Core ([#120](https://github.com/dbt-labs/dbt-external-tables/pull/120))
 
 # dbt-external-tables v0.7.2
 🚨 This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). Projects using this version with `dbt-core` v1.0.x can expect to see a deprecation warning. This will be resolved in the next minor release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt-external-tables v0.7.3
+
+### Fixes
+- Hard code printer width for backwards compatibility with older versions of dbt Core
+
 # dbt-external-tables v0.7.2
 🚨 This is a compatibility release in preparation for `dbt-core` v1.0.0 (🎉). Projects using this version with `dbt-core` v1.0.x can expect to see a deprecation warning. This will be resolved in the next minor release.
 

--- a/macros/common/stage_external_sources.sql
+++ b/macros/common/stage_external_sources.sql
@@ -46,7 +46,7 @@
         {% set run_queue = dbt_external_tables.get_external_build_plan(node) %}
         
         {% do dbt_utils.log_info(loop_label ~ ' SKIP') if run_queue == [] %}
-        {% set width = flags.PRINTER_WIDTH %}
+        {% set width = 80 %} {# hard code this for now, use PRINTER_WIDTH flag in v1.0+ #}
         
         {% for q in run_queue %}
         

--- a/run_test.sh
+++ b/run_test.sh
@@ -9,14 +9,14 @@ if [[ ! -f $VENV ]]; then
     if [ $1 == 'databricks' ]
     then
         echo "Installing dbt-spark"
-        pip install dbt-spark[ODBC]~=0.21.0
+        pip install dbt-spark[ODBC] --upgrade --pre
     elif [ $1 == 'azuresql' ]
     then
         echo "Installing dbt-sqlserver"
-        pip install dbt-sqlserver~=0.21.0
+        pip install dbt-sqlserver --upgrade --pre
     else
         echo "Installing dbt-$1"
-        pip install dbt-$1~=0.21.0
+        pip install dbt-$1 --upgrade --pre
     fi
 fi
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -9,14 +9,14 @@ if [[ ! -f $VENV ]]; then
     if [ $1 == 'databricks' ]
     then
         echo "Installing dbt-spark"
-        pip install dbt-spark[ODBC] --upgrade --pre
+        pip install dbt-spark[ODBC]~=0.21.0
     elif [ $1 == 'azuresql' ]
     then
         echo "Installing dbt-sqlserver"
-        pip install dbt-sqlserver --upgrade --pre
+        pip install dbt-sqlserver~=0.21.0
     else
         echo "Installing dbt-$1"
-        pip install dbt-$1 --upgrade --pre
+        pip install dbt-$1~=0.21.0
     fi
 fi
 


### PR DESCRIPTION
Fixes #121

Hard code printer width for backwards compatibility with older versions of dbt Core. Will change back to `flags.PRINTER_WIDTH` in v0.8.0