### PR TITLE
Snowflake external tables - Added quotes to column name

### DIFF
--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -17,7 +17,7 @@
         {%- for column in columns %}
             {%- set column_quoted = adapter.quote(column.name) if column.quote else column.name %}
             {%- set col_expression -%}
-                {%- set col_id = 'value:c' ~ loop.index if is_csv else 'value:' ~ column.name -%}
+                {%- set col_id = 'value:c' ~ loop.index if is_csv else 'value:' ~ column_quoted -%}
                 (case when is_null_value({{col_id}}) or lower({{col_id}}) = 'null' then null else {{col_id}} end)
             {%- endset %}
             {{column_quoted}} {{column.data_type}} as ({{col_expression}}::{{column.data_type}})


### PR DESCRIPTION
## Description & motivation
Solution to #134 .

When using numeric column names, Snowflake returns a syntax error.
