### PR TITLE
Add self reference for macro

### DIFF
--- a/macros/plugins/spark/get_external_build_plan.sql
+++ b/macros/plugins/spark/get_external_build_plan.sql
@@ -19,7 +19,7 @@
         {% set build_plan = build_plan + dbt_external_tables.refresh_external_table(source_node) %}
     {% endif %}
 
-    {% set recover_partitions = spark__recover_partitions(source_node) %}
+    {% set recover_partitions = dbt_external_tables.spark__recover_partitions(source_node) %}
     {% if recover_partitions|length > 0 %}
     {% set build_plan = build_plan + [
         recover_partitions


### PR DESCRIPTION
Explicitly reference the helper macro 'spark__recover_partitions'

Otherwise running `stage_external_sources` in a Model will error with 'spark__recover_partitions' is undefined.

## Description & motivation
When trying to run `stage_external_sources` in a Model e.g. 

`my_model.sql`
```
{{
    config(
         pre_hook=[
            "{{ dbt_external_tables.stage_external_sources( select='default.my_external_table' ) }}",
        ]
    )
}}
```


dbt errors with 
```
17:58:31    'spark__recover_partitions' is undefined
17:58:31    
17:58:31    > in macro get_external_build_plan (macros/common/get_external_build_plan.sql)
17:58:31    > called by macro stage_external_sources (macros/common/stage_external_sources.sql)
17:58:31    > called by macro spark__get_external_build_plan (macros/plugins/spark/get_external_build_plan.sql)
```

This is due to the helper macro`spark__recover_partitions` not being self-referenced: `dbt_external_tables.spark__recover_partitions`. This commit fixes this.



## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)

