### PR TITLE
add flag `refresh_on_create` for snowflake external table

### DIFF
--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -30,6 +30,9 @@
     {% if external.auto_refresh in (true, false) -%}
       auto_refresh = {{external.auto_refresh}}
     {%- endif %}
+    {% if external.refresh_on_create in (true, false) -%}
+      refresh_on_create = {{external.refresh_on_create}}
+    {%- endif %}
     {% if external.pattern -%} pattern = '{{external.pattern}}' {%- endif %}
     {% if external.integration -%} integration = '{{external.integration}}' {%- endif %}
     file_format = {{external.file_format}}


### PR DESCRIPTION
## Description & motivation

Added refresh_on_create flag for snowflake external tables.

The data lake we're having is
We have a very large number of objects, and if we do not run `refresh_on_create = false`, we will run into a limit on the number of objects.

see: https://docs.snowflake.com/en/sql-reference/sql/create-external-table.html

> If the specified location contains close to 1 million files or more, we recommend that you set REFRESH_ON_CREATE = FALSE. After creating the external table, refresh the metadata incrementally by executing ALTER EXTERNAL TABLE … REFRESH statements that specify subpaths in the location (i.e. subsets of files to include in the refresh) until the metadata includes all of the files in the location

## Checklist
- [x] I have verified that these changes work locally

![image](https://user-images.githubusercontent.com/9821370/183008958-2bba15d0-21bd-4b9a-bbc7-dd557999bfa2.png)

- [x] I have updated the README.md (if applicable)
- [x] I have added an integration test for my fix/feature (if applicable)
In Snowflake, this flag is false by default, so the behavior has not changed.
