### PR TITLE
Fix `column_quoted` set outside the columns loop

### DIFF
--- a/integration_tests/models/plugins/bigquery/bigquery_external.yml
+++ b/integration_tests/models/plugins/bigquery/bigquery_external.yml
@@ -37,7 +37,7 @@ sources:
           options:
             format: csv
             skip_leading_rows: 1
-            hive_partition_uri_prefix: "'gs://dbt-external-tables-testing/csv'"
+            hive_partition_uri_prefix: 'gs://dbt-external-tables-testing/csv'
           partitions: &parts-of-the-people
             - name: section
               data_type: string
@@ -50,7 +50,7 @@ sources:
           options:
             format: csv
             skip_leading_rows: 1
-            hive_partition_uri_prefix: "'gs://dbt-external-tables-testing/csv'"
+            hive_partition_uri_prefix: 'gs://dbt-external-tables-testing/csv'
         tests: *equal-to-the-people
 
       - name: people_csv_override_uris

--- a/macros/plugins/bigquery/create_external_table.sql
+++ b/macros/plugins/bigquery/create_external_table.sql
@@ -14,8 +14,8 @@
 
     create or replace external table {{source(source_node.source_name, source_node.name)}}
         {%- if columns -%}(
-            {%- set column_quoted = adapter.quote(column.name) if column.quote else column.name %}
             {% for column in columns %}
+                {%- set column_quoted = adapter.quote(column.name) if column.quote else column.name %}
                 {{column_quoted}} {{column.data_type}} {{- ',' if not loop.last -}}
             {%- endfor -%}
         )


### PR DESCRIPTION
## Description & motivation
Fixes #165 

Also removed the double quotes in the `hive_partition_uri_prefix` which was causing the tests not work correctly.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added an integration test for my fix/feature (if applicable)
