### PR TITLE
add namespace to redshift_is_ext_tbl call in get_external_build_plan

### DIFF
--- a/macros/plugins/redshift/get_external_build_plan.sql
+++ b/macros/plugins/redshift/get_external_build_plan.sql
@@ -2,7 +2,7 @@
 
     {% set build_plan = [] %}
     
-    {% set create_or_replace = (var('ext_full_refresh', false) or not redshift_is_ext_tbl(source_node)) %}
+    {% set create_or_replace = (var('ext_full_refresh', false) or not dbt_external_tables.redshift_is_ext_tbl(source_node)) %}
     
     {% if create_or_replace %}
 


### PR DESCRIPTION
## Description & motivation

When staging external tables as an on-run-start hook, as in 
```yaml
on-run-start:
  - "{% if target.name == 'prod' and var('refresh_external_tables')%}{{ dbt_external_tables.stage_external_sources() }}{% endif %}"
``` 
  the macro fails with 
```bash
Runtime Error
  Compilation Error in operation redshift-on-run-start-1 (./dbt_project.yml)
    'redshift_is_ext_tbl' is undefined
    > in macro get_external_build_plan (macros/common/get_external_build_plan.sql)
    > called by macro stage_external_sources (macros/common/stage_external_sources.sql)
    > called by macro redshift__get_external_build_plan (macros/plugins/redshift/get_external_build_plan.sql)
    > called by operation stratasan_redshift-on-run-start-1 (./dbt_project.yml)
``` 
When running the macro from the CLI I get the expected results of building/rebuilding/skipping the table. 

The issue was fixed with referencing the `redshift_is_ext_tbl` macro by its namespace, as in `dbt_external_tables.redshift_is_ext_tbl`


    


## Checklist
- [X] I have verified that these changes work locally
- [X] I have updated the README.md (if applicable)
- [X] I have added an integration test for my fix/feature (if applicable)
