### PR TITLE
fix: wrong timezone processing in snowpipe

### DIFF
--- a/macros/plugins/snowflake/snowpipe/get_copy_sql.sql
+++ b/macros/plugins/snowflake/snowpipe/get_copy_sql.sql
@@ -25,7 +25,7 @@
         {% endif %}
             metadata$filename::varchar as metadata_filename,
             metadata$file_row_number::bigint as metadata_file_row_number,
-            current_timestamp::timestamp as _dbt_copied_at
+            sysdate()::timestamp as _dbt_copied_at
         from {{external.location}} {# stage #}
     )
     file_format = {{external.file_format}}

--- a/sample_sources/snowflake.yml
+++ b/sample_sources/snowflake.yml
@@ -56,7 +56,7 @@ sources:
         # specified for a snowpiped table:
         #   `metadata_filename`: the file from which this row was loaded
         #   `metadata_file_row_number`: the numbered row this was in that file
-        #   `_dbt_copied_at`: the current_timestamp when this row was loaded (backfilled or piped)
+        #   `_dbt_copied_at`: the current timestamp (no timezone) when this row was loaded (backfilled or piped)
         #
         # if you do not specify *any* columns for a snowpiped table, dbt will also
         # include `value`, the JSON blob of all file contents.


### PR DESCRIPTION
## Description & motivation

Now it is using `current_timestamp::timestamp` function to get current timestamp, but this is wrong because type of current_timestamp is TIMESTAMP_LTZ(local time zone) and when converted to timestamp_ntz(no time zone) by `::timestamp` timezone is forcibly removed and showing wrong timestamp.
We should use `sysdate()` instead.
https://docs.snowflake.com/en/sql-reference/functions/sysdate.html

<img width="879" alt="image" src="https://user-images.githubusercontent.com/20131692/216609787-f61682d6-d7e1-4c96-8361-eb822e24ed9c.png">

### How i checked:
Look at dbt log and generated raw sql. Run that sql with this update manually on snowflake, and check that timezone issue is fixed.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added an integration test for my fix/feature (if applicable)
