### PR TITLE
support optional tags argument to select source tables to stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ version: 2
 
 sources:
   - name: snowplow
+    tags:
+    - daily                 # optional: associate tags to all tables in the source
     tables:
       - name: event
         description: >
@@ -86,7 +88,9 @@ sources:
             - name: collector_date
               data_type: date
               ...           # database-specific properties
-
+        tags:               # optional: associate additional tags to a table
+          - sales
+          - finance
         # Specify ALL column names + datatypes.
         # Column order must match for CSVs, column names must match for other formats.
         # Some databases support schema inference.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ $ dbt run-operation stage_external_sources --args "select: snowplow logs"
 
 # stage a particular external source table:
 $ dbt run-operation stage_external_sources --args "select: snowplow.event"
+
+# stage a particular external sources having specific tags:
+$ dbt run-operation stage_external_sources --args "tags: finance sales"
+
+# stage a particular external sources and stage sources having specific tags:
+$ dbt run-operation stage_external_sources --args "select: logs, tags: finance"
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ sources:
             - name: collector_date
               data_type: date
               ...           # database-specific properties
-        tags:               # optional: associate additional tags to a table
+        tags:               # optional: associate additional tags to a source table
           - sales
           - finance
         # Specify ALL column names + datatypes.

--- a/macros/common/stage_external_sources.sql
+++ b/macros/common/stage_external_sources.sql
@@ -1,4 +1,4 @@
-{% macro stage_external_sources(select=none) %}
+{% macro stage_external_sources(select=none, tags=none) %}
 
     {% set sources_to_stage = [] %}
     
@@ -23,8 +23,24 @@
                     {% endif %}
                     
                 {% endfor %}
-                        
-            {% else %}
+
+            {% endif%}
+            
+            -- Opitionally and additionally stage external sources having any
+            -- of the tags provided in the tags argument
+            {% if tags %}
+
+                {% for tag in tags.split(' ') %}
+                    
+                    {% if tag in node.tags and node not in sources_to_stage %}
+                        {% do sources_to_stage.append(node) %}
+                    {% endif %}
+
+                {% endfor %}
+            
+            {% endif %}
+
+            {% if not select and not tags %}
             
                 {% do sources_to_stage.append(node) %}
                 


### PR DESCRIPTION
## Description & motivation
Usability improvements to source table selection by supporting an optional tags argument. 

Feature benefits:
- ability to maintain a short hand way of selecting sources via the 'tags' attributes in the source config and source tables
- ability to refresh tables across multiple sources without having to:
- - list a large number of tables with the select argument
- - create/refresh every table defined in a source because its shorter than listing tables with the select argument
- - create/refresh all sources because they are dispersed across multiple sources and it is easier to just run all external tables

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added an integration test for my fix/feature (if applicable)
