### PR TITLE
update test command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ jobs:
       - checkout
       - run:
           name: "Run Tests - Redshift"
-          command: ./run_test.sh redshift
+          command: |
+            set -e
+            ./run_test.sh redshift
       - store_artifacts:
           path: ./logs
 
@@ -22,7 +24,9 @@ jobs:
       - checkout
       - run:
           name: "Run Tests - Snowflake"
-          command: ./run_test.sh snowflake
+          command: |
+            set -e
+            ./run_test.sh snowflake
       - store_artifacts:
           path: ./logs
 
@@ -38,7 +42,9 @@ jobs:
           command: echo $BIGQUERY_SERVICE_ACCOUNT_JSON > ${HOME}/bigquery-service-key.json
       - run:
           name: "Run Tests - BigQuery"
-          command: ./run_test.sh bigquery
+          command: |
+            set -e
+            ./run_test.sh bigquery
       - store_artifacts:
           path: ./logs
 
@@ -55,7 +61,9 @@ jobs:
       - checkout
       - run:
           name: "Run Tests - Databricks"
-          command: ./run_test.sh databricks
+          command: |
+            set -e
+            ./run_test.sh databricks
       - store_artifacts:
           path: ./logs
 
@@ -96,7 +104,9 @@ jobs:
       - azure-cli/login-with-service-principal: *azure-creds
       - run:
           name: "Run Tests - azuresql"
-          command: ./run_test.sh azuresql
+          command: |
+            set -e
+            ./run_test.sh azuresql
       - store_artifacts:
           path: ./logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,7 @@ jobs:
       - checkout
       - run:
           name: "Run Tests - Redshift"
-          command: |
-            set -e
-            ./run_test.sh redshift
+          command: ./run_test.sh redshift
       - store_artifacts:
           path: ./logs
 
@@ -24,9 +22,7 @@ jobs:
       - checkout
       - run:
           name: "Run Tests - Snowflake"
-          command: |
-            set -e
-            ./run_test.sh snowflake
+          command: ./run_test.sh snowflake
       - store_artifacts:
           path: ./logs
 
@@ -42,9 +38,7 @@ jobs:
           command: echo $BIGQUERY_SERVICE_ACCOUNT_JSON > ${HOME}/bigquery-service-key.json
       - run:
           name: "Run Tests - BigQuery"
-          command: |
-            set -e
-            ./run_test.sh bigquery
+          command: ./run_test.sh bigquery
       - store_artifacts:
           path: ./logs
 
@@ -61,9 +55,7 @@ jobs:
       - checkout
       - run:
           name: "Run Tests - Databricks"
-          command: |
-            set -e
-            ./run_test.sh databricks
+          command: ./run_test.sh databricks
       - store_artifacts:
           path: ./logs
 
@@ -104,9 +96,7 @@ jobs:
       - azure-cli/login-with-service-principal: *azure-creds
       - run:
           name: "Run Tests - azuresql"
-          command: |
-            set -e
-            ./run_test.sh azuresql
+          command: ./run_test.sh azuresql
       - store_artifacts:
           path: ./logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
       - run:
           name: "Run Tests - Redshift"
           command: ./run_test.sh redshift
-      - store_artifacts:
-          path: ./logs
+      - store_artifacts: &artifacts-path
+          path: integration_tests/logs
 
   integration-snowflake:
     docker:
@@ -23,8 +23,7 @@ jobs:
       - run:
           name: "Run Tests - Snowflake"
           command: ./run_test.sh snowflake
-      - store_artifacts:
-          path: ./logs
+      - store_artifacts: *artifacts-path
 
   integration-bigquery:
     environment:
@@ -39,8 +38,7 @@ jobs:
       - run:
           name: "Run Tests - BigQuery"
           command: ./run_test.sh bigquery
-      - store_artifacts:
-          path: ./logs
+      - store_artifacts: *artifacts-path
 
   integration-databricks:
     environment:
@@ -56,8 +54,7 @@ jobs:
       - run:
           name: "Run Tests - Databricks"
           command: ./run_test.sh databricks
-      - store_artifacts:
-          path: ./logs
+      - store_artifacts: *artifacts-path
 
   # DISABLED FOR NOW
   integration-synapse:

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
+set -eo pipefail
+
 echo "Setting up virtual environment"
 VENV="venv/bin/activate"
 
 if [[ ! -f $VENV ]]; then
+    sudo apt update
+    sudo apt install python3.8-venv
     python3.8 -m venv venv
     . $VENV
     pip install --upgrade pip setuptools
@@ -34,6 +38,6 @@ echo "Starting integration tests"
 dbt deps --target $1
 dbt seed --full-refresh --target $1
 dbt run-operation prep_external --target $1
-dbt run-operation stage_external_sources --not_vars 'ext_full_refresh: true' --target $1
+dbt run-operation stage_external_sources --vars 'ext_full_refresh: true' --target $1
 dbt run-operation stage_external_sources --target $1
 dbt test --target $1

--- a/run_test.sh
+++ b/run_test.sh
@@ -5,26 +5,26 @@ echo "Setting up virtual environment"
 VENV="venv/bin/activate"
 
 if [[ ! -f $VENV ]]; then
-    sudo apt update
-    sudo apt install python3.8-venv
-    python3.8 -m venv venv
-    . $VENV
-    pip install --upgrade pip setuptools
+    # sudo apt update
+    # sudo apt install python3.8-venv
+    # python3.8 -m venv venv
+    # . $VENV
+    pip3 install --upgrade pip setuptools
     if [ $1 == 'databricks' ]
     then
         echo "Installing dbt-spark"
-        pip install dbt-spark[ODBC] --upgrade --pre
+        pip3 install dbt-spark[ODBC] --upgrade --pre
     elif [ $1 == 'azuresql' ]
     then
         echo "Installing dbt-sqlserver"
-        pip install dbt-sqlserver --upgrade --pre
+        pip3 install dbt-sqlserver --upgrade --pre
     else
         echo "Installing dbt-$1"
-        pip install dbt-$1 --upgrade --pre
+        pip3 install dbt-$1 --upgrade --pre
     fi
 fi
 
-. $VENV
+# . $VENV
 echo "Changing working directory: integration_tests"
 cd integration_tests
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -34,6 +34,6 @@ echo "Starting integration tests"
 dbt deps --target $1
 dbt seed --full-refresh --target $1
 dbt run-operation prep_external --target $1
-dbt run-operation stage_external_sources --var 'ext_full_refresh: true' --target $1
+dbt run-operation stage_external_sources --vars 'ext_full_refresh: true' --target $1
 dbt run-operation stage_external_sources --target $1
 dbt test --target $1

--- a/run_test.sh
+++ b/run_test.sh
@@ -34,6 +34,6 @@ echo "Starting integration tests"
 dbt deps --target $1
 dbt seed --full-refresh --target $1
 dbt run-operation prep_external --target $1
-dbt run-operation stage_external_sources --vars 'ext_full_refresh: true' --target $1
+dbt run-operation stage_external_sources --not_vars 'ext_full_refresh: true' --target $1
 dbt run-operation stage_external_sources --target $1
 dbt test --target $1

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,30 +1,27 @@
 #!/bin/bash
-set -eo pipefail
 
 echo "Setting up virtual environment"
 VENV="venv/bin/activate"
 
 if [[ ! -f $VENV ]]; then
-    # sudo apt update
-    # sudo apt install python3.8-venv
-    # python3.8 -m venv venv
-    # . $VENV
-    pip3 install --upgrade pip setuptools
+    python3.8 -m venv venv
+    . $VENV
+    pip install --upgrade pip setuptools
     if [ $1 == 'databricks' ]
     then
         echo "Installing dbt-spark"
-        pip3 install dbt-spark[ODBC] --upgrade --pre
+        pip install dbt-spark[ODBC] --upgrade --pre
     elif [ $1 == 'azuresql' ]
     then
         echo "Installing dbt-sqlserver"
-        pip3 install dbt-sqlserver --upgrade --pre
+        pip install dbt-sqlserver --upgrade --pre
     else
         echo "Installing dbt-$1"
-        pip3 install dbt-$1 --upgrade --pre
+        pip install dbt-$1 --upgrade --pre
     fi
 fi
 
-# . $VENV
+. $VENV
 echo "Changing working directory: integration_tests"
 cd integration_tests
 
@@ -35,6 +32,7 @@ if [[ ! -e ~/.dbt/profiles.yml ]]; then
 fi
 
 echo "Starting integration tests"
+set -eo pipefail
 dbt deps --target $1
 dbt seed --full-refresh --target $1
 dbt run-operation prep_external --target $1


### PR DESCRIPTION
## Description & motivation

Tests are failing because `--var` can't be used anymore with dbt 1.5. Need to use the right flag here `--vars`.

Also making a quick small change while we're at it - previously an error in one of the individual shell commands (individual dbt invocations) results in a passing overall CircleCI step. This means if:

```sh
dbt deps --target $1 ✅
dbt seed --full-refresh --target $1 ✅
dbt run-operation prep_external --target $1 ✅
dbt run-operation stage_external_sources --vars 'ext_full_refresh: true' --target $1 ❌
dbt run-operation stage_external_sources --target $1 ✅
dbt test --target $1 ✅
```

All of those shell commands / dbt invocations are considered a single CircleCI step (see `command:`):
https://github.com/dbt-labs/dbt-external-tables/blob/34c1cc4bbcf28ccb0243807441bf642e801ad158/.circleci/config.yml#L39-L43

The CircleCI run step on an aggregate still passes - we should make these fail. Examples below:

https://app.circleci.com/pipelines/github/dbt-labs/dbt-external-tables/291/workflows/cd1bc6eb-8c67-4932-b96c-bb201a4fa189/jobs/1297

https://app.circleci.com/pipelines/github/dbt-labs/dbt-external-tables/291/workflows/cd1bc6eb-8c67-4932-b96c-bb201a4fa189/jobs/1298

And writeup from CircleCI:

https://support.circleci.com/hc/en-us/articles/115015733328-Step-Should-Fail-but-Job-Finished-Successfully

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added an integration test for my fix/feature (if applicable)
