### PR TITLE
Snowflake: Add expression parameter to columns

### DIFF
--- a/integration_tests/models/plugins/snowflake/snowflake_external.yml
+++ b/integration_tests/models/plugins/snowflake/snowflake_external.yml
@@ -20,9 +20,11 @@ sources:
             data_type: varchar(64)
           - name: email
             data_type: varchar(64)
-          - name: email_domain
+          - name: email domain
             data_type: varchar(64)
-            expression: split_part(value:email, '@', 2)
+            quote: true
+            identifier: email
+            expression: split_part(value:email::VARCHAR, '@', 2)
         tests: &equal-to-the-people
           - dbt_utils.equality:
               compare_model: ref('people')

--- a/integration_tests/models/plugins/snowflake/snowflake_external.yml
+++ b/integration_tests/models/plugins/snowflake/snowflake_external.yml
@@ -20,6 +20,9 @@ sources:
             data_type: varchar(64)
           - name: email
             data_type: varchar(64)
+          - name: email_domain
+            data_type: varchar(64)
+            expression: split_part(value:email, '@', 2)
         tests: &equal-to-the-people
           - dbt_utils.equality:
               compare_model: ref('people')

--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -17,8 +17,12 @@
         {%- for column in columns %}
             {%- set column_quoted = adapter.quote(column.name) if column.quote else column.name %}
             {%- set col_expression -%}
-                {%- set col_id = 'value:c' ~ loop.index if is_csv else 'value:' ~ column_quoted -%}
-                (case when is_null_value({{col_id}}) or lower({{col_id}}) = 'null' then null else {{col_id}} end)
+                {%- if column.expression -%}
+                    {{column.expression}}
+                {%- else -%}
+                    {%- set col_id = 'value:c' ~ loop.index if is_csv else 'value:' ~ column_quoted -%}
+                    (case when is_null_value({{col_id}}) or lower({{col_id}}) = 'null' then null else {{col_id}} end)
+                {%- endif -%}
             {%- endset %}
             {{column_quoted}} {{column.data_type}} as ({{col_expression}}::{{column.data_type}})
             {{- ',' if not loop.last -}}

--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -16,11 +16,20 @@
         {%- endfor -%}{%- endif -%}
         {%- for column in columns %}
             {%- set column_quoted = adapter.quote(column.name) if column.quote else column.name %}
+            {%- set column_identifier -%}
+                {%- if 'identifier' in column and column.quote -%}
+                    {{adapter.quote(column.identifier)}}
+                {%- elif 'identifier' in column -%}
+                    {{column.identifier}}
+                {%- else -%}
+                    {{column_quoted}}
+                {%- endif -%}
+            {%- endset %}
             {%- set col_expression -%}
                 {%- if column.expression -%}
                     {{column.expression}}
                 {%- else -%}
-                    {%- set col_id = 'value:c' ~ loop.index if is_csv else 'value:' ~ column_quoted -%}
+                    {%- set col_id = 'value:c' ~ loop.index if is_csv else 'value:' ~ column_identifier -%}
                     (case when is_null_value({{col_id}}) or lower({{col_id}}) = 'null' then null else {{col_id}} end)
                 {%- endif -%}
             {%- endset %}

--- a/sample_sources/snowflake.yml
+++ b/sample_sources/snowflake.yml
@@ -32,6 +32,11 @@ sources:
           - name: etl_tstamp
             data_type: timestamp
             description: "Timestamp event began ETL"
+          - name: etl_date
+            data_type: date
+            description: "Date event began ETL"
+            # Expressions can manipulate the variant value prior to casting to data_type.
+            expression: TRY_TO_DATE(VALUE:etl_date::VARCHAR, 'YYYYMMDD')
           - name: contexts
             data_type: variant
             description: "Contexts attached to event by Tracker"

--- a/sample_sources/snowflake.yml
+++ b/sample_sources/snowflake.yml
@@ -36,7 +36,7 @@ sources:
             data_type: date
             description: "Date event began ETL"
             # Expressions can manipulate the variant value prior to casting to data_type.
-            expression: TRY_TO_DATE(VALUE:etl_date::VARCHAR, 'YYYYMMDD')
+            expression: TRY_TO_DATE(VALUE:etl_tstamp::VARCHAR, 'YYYYMMDD')
           - name: contexts
             data_type: variant
             description: "Contexts attached to event by Tracker"

--- a/sample_sources/snowflake.yml
+++ b/sample_sources/snowflake.yml
@@ -32,6 +32,13 @@ sources:
           - name: etl_tstamp
             data_type: timestamp
             description: "Timestamp event began ETL"
+          - name: etl timestamp
+            # Use double-quoted identifiers for name and identifier
+            quote: true
+            # Specifying identifier lets us rename etl_tstamp to "etl timestamp"
+            identifier: etl_tstamp
+            data_type: timestamp
+            description: "Timestamp event began ETL with a double quoted identifier"
           - name: etl_date
             data_type: date
             description: "Date event began ETL"


### PR DESCRIPTION
## Description & motivation
resolves: #140
- Implements #140 - extending the snowflake plugin to allow custom expression for virtual columns
- Adds support for column identifiers in Snowflake external tables. Allowing identifier in addition to name enables aliasing virtual columns within the external table model rather than a subsequent model.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable) <- Not applicable, but updated sample_sources/snowflake.yml
- [x] I have added an integration test for my fix/feature (if applicable)
