### PR TITLE
BigQuery check if schema already exists before trying to create it

### DIFF
--- a/macros/plugins/bigquery/create_external_schema.sql
+++ b/macros/plugins/bigquery/create_external_schema.sql
@@ -20,7 +20,8 @@
         {%- set ddl -%}
             create schema if not exists {{ fqn }}
         {%- endset -%}
-    {%- endif -%}
-
-    {{ return(ddl) }}
+        {{ return(ddl) }}
+    {%- else -%}
+        {{ return('') }}
+    {% endif %} 
 {%- endmacro -%}

--- a/macros/plugins/bigquery/create_external_schema.sql
+++ b/macros/plugins/bigquery/create_external_schema.sql
@@ -7,9 +7,20 @@
         {%- endif -%}
     {%- endset -%}
 
-    {%- set ddl -%}
-        create schema if not exists {{ fqn }}
-    {%- endset -%}
+    {% set schema_exists_query %}
+        select * from {{ source_node.database }}.INFORMATION_SCHEMA.SCHEMATA where schema_name = '{{ source_node.schema }}' limit 1
+    {% endset %}
+    {% if execute %}
+        {% set schema_exists = run_query(schema_exists_query)|length > 0 %}
+    {% else %}
+        {% set schema_exists = false %}
+    {% endif %}  
+
+    {%- if not schema_exists -%}
+        {%- set ddl -%}
+            create schema if not exists {{ fqn }}
+        {%- endset -%}
+    {%- endif -%}
 
     {{ return(ddl) }}
 {%- endmacro -%}

--- a/macros/plugins/bigquery/get_external_build_plan.sql
+++ b/macros/plugins/bigquery/get_external_build_plan.sql
@@ -11,10 +11,16 @@
     {% set create_or_replace = (old_relation is none or var('ext_full_refresh', false)) %}
 
     {% if create_or_replace %}
-        {% set build_plan = build_plan + [
-            dbt_external_tables.create_external_schema(source_node),
-            dbt_external_tables.create_external_table(source_node)
-        ] %}
+        {% if not dbt_external_tables.create_external_schema(source_node)|length %}
+            {% set build_plan = build_plan + [
+                dbt_external_tables.create_external_table(source_node)
+            ] %}
+        {% else %}
+            {% set build_plan = build_plan + [
+                dbt_external_tables.create_external_schema(source_node),
+                dbt_external_tables.create_external_table(source_node)
+            ] %}
+        {% endif %}
     {% else %}
         {% set build_plan = build_plan + dbt_external_tables.refresh_external_table(source_node) %}
     {% endif %}

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Setting up virtual environment"
+echo "Setting up virtual environment for dbt-$1"
 VENV="venv/bin/activate"
 
 if [[ ! -f $VENV ]]; then


### PR DESCRIPTION
## Description & motivation
Before trying to create a new dataset we should check if it already exists without using the CREATE statement.
It could be that the DBT SA or DBT user that runs the command does not has the permission to create a dataset.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added an integration test for my fix/feature (if applicable)
