### PR TITLE
Disable CI for Databricks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,10 +107,10 @@ workflows:
           context: profile-snowflake
       - integration-bigquery:
           context: profile-bigquery
-      - integration-databricks:
-          context:
-            - aws-credentials
-            - profile-databricks
+      # - integration-databricks:
+      #     context:
+      #       - aws-credentials
+      #       - profile-databricks
       #- integration-synapse:
       #    context: profile-synapse
       #- integration-azuresql:


### PR DESCRIPTION
## Description & motivation

Since CI is failing for Databricks for reasons unrelated to PRs, disabling it until it can be properly addressed by resolving https://github.com/dbt-labs/dbt-external-tables/issues/228.