### PR TITLE
Handle BigQuery non-string option 'max_staleness'

### DIFF
--- a/integration_tests/models/plugins/bigquery/bigquery_external.yml
+++ b/integration_tests/models/plugins/bigquery/bigquery_external.yml
@@ -67,6 +67,16 @@ sources:
         columns: *cols-of-the-people
         tests: *equal-to-the-people
 
+      - name: people_csv_with_max_staleness
+        external:
+          location: 'gs://dbt-external-tables-testing/csv/*'
+          options:
+            format: csv
+            skip_leading_rows: 1
+            max_staleness: INTERVAL 1 HOUR
+        columns: *cols-of-the-people
+        tests: *equal-to-the-people
+
 #      - name: people_json_unpartitioned
 #        external: &json-people
 #          location: 'gs://dbt-external-tables-testing/json/*'

--- a/macros/plugins/bigquery/create_external_table.sql
+++ b/macros/plugins/bigquery/create_external_table.sql
@@ -4,6 +4,7 @@
     {%- set external = source_node.external -%}
     {%- set partitions = external.partitions -%}
     {%- set options = external.options -%}
+    {%- set non_string_options = ['max_staleness'] %}
 
     {% if options is mapping and options.get('connection_name', none) %}
         {% set connection_name = options.pop('connection_name') %}
@@ -38,7 +39,7 @@
             uris = [{%- for uri in uris -%} '{{uri}}' {{- "," if not loop.last}} {%- endfor -%}]
             {%- if options is mapping -%}
             {%- for key, value in options.items() if key != 'uris' %}
-                {%- if value is string -%}
+                {%- if value is string and key not in non_string_options -%}
                 , {{key}} = '{{value}}'
                 {%- else -%}
                 , {{key}} = {{value}}


### PR DESCRIPTION
## Description & motivation

Fix for issue #231:

Option item `max_staleness` in BigQuery must be passed as an INTERVAL, not a string. 
But it's flagged as a string in YAML config. 

Therefore compiled SQL code is:

```sql
create or replace external table `... my_table_name`
options (
    max_staleness = 'INTERVAL 1 HOUR'  -- <-- Quotes makes BigQuery angry here
)
```

while it should be:

```sql
create or replace external table `... my_table_name`
options (
    max_staleness = INTERVAL 1 HOUR  -- <-- No quote, BigQuery's happy
)
```

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added an integration test for my fix/feature (if applicable)
