### PR TITLE
snowflake delta format

### DIFF
--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -51,6 +51,9 @@
     {% if external.auto_refresh in (true, false) -%}
       auto_refresh = {{external.auto_refresh}}
     {%- endif %}
+    {% if external.table_format | lower == "delta" %}
+      refresh_on_create = false
+    {% endif %}
     {% if external.pattern -%} pattern = '{{external.pattern}}' {%- endif %}
     {% if external.integration -%} integration = '{{external.integration}}' {%- endif %}
     file_format = {{external.file_format}}

--- a/macros/plugins/snowflake/refresh_external_table.sql
+++ b/macros/plugins/snowflake/refresh_external_table.sql
@@ -5,8 +5,9 @@
     
     {% set auto_refresh = external.get('auto_refresh', false) %}
     {% set partitions = external.get('partitions', none) %}
+    {% set delta_format = (external.table_format | lower == "delta") %}
     
-    {% set manual_refresh = (partitions and not auto_refresh) %}
+    {% set manual_refresh = not auto_refresh %}
     
     {% if manual_refresh %}
 


### PR DESCRIPTION
## Description & motivation

resolves: #198 

Snowflake supports external tables on Delta format external stages, but they do not support automatic refresh.
When creating them, it's mandatory to specify `refresh_on_create = false`.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added an integration test for my fix/feature (if applicable)
