### PR TITLE
Use metadata for _dbt_copied_at in Snowpipe

### DIFF
--- a/macros/plugins/snowflake/snowpipe/get_copy_sql.sql
+++ b/macros/plugins/snowflake/snowpipe/get_copy_sql.sql
@@ -26,7 +26,7 @@
             metadata$filename::varchar as metadata_filename,
             metadata$file_row_number::bigint as metadata_file_row_number,
             metadata$file_last_modified::timestamp as metadata_file_last_modified,
-            current_timestamp::timestamp as _dbt_copied_at
+            metadata$start_scan_time::timestamp as _dbt_copied_at
         from {{external.location}} {# stage #}
     )
     file_format = {{external.file_format}}


### PR DESCRIPTION
## Description & motivation

resovles: #281

This change uses `metadata$start_scan_time` instead of `current_timestamp` for the `_dbt_copied_at` field on Snowflake Snowpipe creation.

This is the method recommended in the [Snowflake docs](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-ts#load-times-inserted-using-current-timestamp-earlier-than-load-time-values-in-copy-history-view)

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [na] I have added an integration test for my fix/feature (if applicable)
