### PR TITLE
added ignore_case for Snowflake

### DIFF
--- a/integration_tests/models/plugins/snowflake/people_ignore_case.sql
+++ b/integration_tests/models/plugins/snowflake/people_ignore_case.sql
@@ -1,0 +1,4 @@
+SELECT
+ {{ dbt_utils.star(from=ref('people'), except=['email']) }},
+  email as Email
+FROM {{ ref('people') }}

--- a/integration_tests/models/plugins/snowflake/snowflake_external.yml
+++ b/integration_tests/models/plugins/snowflake/snowflake_external.yml
@@ -201,3 +201,25 @@ sources:
                 - last_name
                 - email
                 - email_domain
+
+      - name: people_ignore_case
+        external: 
+          <<: *csv-people
+          ignore_case: true
+        columns:
+          - name: id
+            data_type: int
+          - name: first_name
+            data_type: varchar(64)
+          - name: last_name
+            data_type: varchar(64)
+          - name: email
+            data_type: varchar(64)
+        tests:
+          - dbt_utils.equality:
+              compare_model: ref('people_ignore_case')
+              compare_columns:
+                - id
+                - first_name
+                - last_name
+                - email         

--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -4,6 +4,7 @@
     {%- set external = source_node.external -%}
     {%- set partitions = external.partitions -%}
     {%- set infer_schema = external.infer_schema -%}
+    {%- set ignore_case = external.ignore_case -%}
 
     {% if infer_schema %}
         {% set query_infer_schema %}
@@ -40,7 +41,11 @@
                     {%- if column.expression -%}
                         {{column.expression}}
                     {%- else -%}
+                        {%- if ignore_case -%}
+                        {%- set col_id = 'value:c' ~ loop.index if is_csv else 'GET_IGNORE_CASE($1, ' ~ "'"~ column_alias ~"'"~ ')' -%}
+                        {%- else -%}
                         {%- set col_id = 'value:c' ~ loop.index if is_csv else 'value:' ~ column_alias -%}
+                        {%- endif -%}
                         (case when is_null_value({{col_id}}) or lower({{col_id}}) = 'null' then null else {{col_id}} end)
                     {%- endif -%}
                 {%- endset %}


### PR DESCRIPTION
## Description & motivation
Snowflake external tables by default do not ignore case of columns of underlying external File, this poses a challenge when defining to exactly define the column names to be able to successfully create external tables and have the column values populated.

This PR adds the capability to use GET_IGNORE_CASE function to lookup the column value instead of standard `value:` reference. 

## Checklist
- [ *] I have verified that these changes work locally
- [* ] I have updated the README.md (if applicable)
- [* ] I have added an integration test for my fix/feature (if applicable)
