### PR TITLE
remove synapse from testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,14 @@ jobs:
         BIGQUERY_PROJECT: ${{ vars.BIGQUERY_PROJECT }}
         BIGQUERY_SCHEMA: "integration_tests_bigquery_${{ github.run_number }}"
         # synapse
-        SYNAPSE_DRIVER: ${{ vars.SYNAPSE_DRIVER }}
-        SYNAPSE_HOST: ${{ vars.SYNAPSE_HOST }}
-        SYNAPSE_PORT: ${{ vars.SYNAPSE_PORT }}
-        SYNAPSE_DATABASE: ${{ vars.SYNAPSE_DATABASE }}
-        SYNAPSE_AUTHENTICATION: ${{ vars.SYNAPSE_AUTHENTICATION }}
-        SYNAPSE_TENANT_ID: ${{ vars.SYNAPSE_TENANT_ID }}
-        SYNAPSE_CLIENT_ID: ${{ vars.SYNAPSE_CLIENT_ID }}
+        # temporarily removed until we can get the cluster hooked up to the blob correctly
+        # SYNAPSE_DRIVER: ${{ vars.SYNAPSE_DRIVER }}
+        # SYNAPSE_HOST: ${{ vars.SYNAPSE_HOST }}
+        # SYNAPSE_PORT: ${{ vars.SYNAPSE_PORT }}
+        # SYNAPSE_DATABASE: ${{ vars.SYNAPSE_DATABASE }}
+        # SYNAPSE_AUTHENTICATION: ${{ vars.SYNAPSE_AUTHENTICATION }}
+        # SYNAPSE_TENANT_ID: ${{ vars.SYNAPSE_TENANT_ID }}
+        # SYNAPSE_CLIENT_ID: ${{ vars.SYNAPSE_CLIENT_ID }}
 
       secrets:
         DBT_ENV_SECRET_REDSHIFT_PASS: ${{ secrets.DBT_ENV_SECRET_REDSHIFT_PASS }}

--- a/supported_adapters.env
+++ b/supported_adapters.env
@@ -1,1 +1,1 @@
-SUPPORTED_ADAPTERS=snowflake,redshift,bigquery,synapse
+SUPPORTED_ADAPTERS=snowflake,redshift,bigquery

--- a/tox.ini
+++ b/tox.ini
@@ -80,6 +80,7 @@ commands =
     dbt test --target bigquery
 
 # run dbt commands directly, assumes dbt is already installed in environment
+# temporarily removed from CI testing until we can get the cluster hooked up to the blob correctly
 [testenv:dbt_integration_synapse]
 changedir = integration_tests
 allowlist_externals = 


### PR DESCRIPTION
## Description & motivation
Removes synapse from testing matrix until we can hook up teh synapse cluster correctly to the blob.

error in CI:
```13:51:12  1 of 2 (3) SET ANSI_NULLS ON;    SET QUOTED_IDENTIFIER ON;    create external table "dbt_ex...  
14:14:40  Encountered an error while running operation: Database Error
  ('42000', "[42000] [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]External file access failed due to internal error: 'Parameters provided to connect to the Azure storage account are not valid.' (105019) (SQLExecDirectW)")
dbt_integration_synapse: exit 1 (1413.95 seconds) /project/dbt_packages/dbt_external_tables/integration_tests> dbt run-operation dbt_external_tables.stage_external_sources --vars 'ext_full_refresh: true' --target synapse pid=96
  dbt_integration_synapse: FAIL code 1 (1434.33=setup[0.44]+cmd[1.97,10.97,2.76,4.23,1413.95] seconds)
```

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added an integration test for my fix/feature (if applicable)
