### PR TITLE
added docs for teradata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This package provides:
 * Spark
 * Synapse
 * Azure SQL
+* Teradata [docs](https://github.com/Teradata/dbt-teradata/blob/main/README.md#dbt-external-tables)
 
 ![sample docs](etc/sample_docs.png)
 

--- a/sample_sources/teradata.yml
+++ b/sample_sources/teradata.yml
@@ -1,0 +1,56 @@
+version: 2
+sources:
+  - name: teradata_external
+    schema: "{{ target.schema }}"
+    loader: S3
+
+    tables:
+      # csv file format example
+      - name: people_csv
+        external: 
+          location: "/s3/s3.amazonaws.com/dbt-external-tables-testing/csv/"
+          file_format: "TEXTFILE"
+          row_format: '{"field_delimiter":",","record_delimiter":"\n","character_set":"LATIN"}'
+          using: |
+            PATHPATTERN  ('$var1/$section/$var3')
+          tbl_properties: |
+            MAP = TD_MAP1
+            ,EXTERNAL SECURITY  MyAuthObj
+          partitions:
+            - name: section
+              data_type: CHAR(1)
+        columns:
+          - name: id
+            data_type: int
+          - name: first_name
+            data_type: varchar(64)
+          - name: last_name
+            data_type: varchar(64)
+          - name: email
+            data_type: varchar(64)
+
+      # json file format example
+      - name: people_json
+        external:
+          location: '/s3/s3.amazonaws.com/dbt-external-tables-testing/json/'
+          using: |
+            STOREDAS('TEXTFILE')
+            ROWFORMAT('{"record_delimiter":"\n", "character_set":"cs_value"}')
+            PATHPATTERN  ('$var1/$section/$var3')
+          tbl_properties: |
+            MAP = TD_MAP1
+            ,EXTERNAL SECURITY  MyAuthObj
+          partitions:
+            - name: section
+              data_type: CHAR(1)
+      
+      # parquet file format example
+      - name: people_pq
+        external:
+          location: "/s3/s3.amazonaws.com/dbt-external-tables-testing/parquet/"
+          using: |
+            STOREDAS('PARQUET')
+            PATHPATTERN  ('$var1/$section/$var3')
+          tbl_properties: |
+            MAP = TD_MAP1
+            ,EXTERNAL SECURITY  MyAuthObj


### PR DESCRIPTION
## Description & motivation
This PR adds Teradata as a supported database for dbt-external-tables.
Also, sample sources with associated teradata syntax have been added.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
