### PR TITLE
Fix Fabric column nullity bug, compile-time false log, and add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in this project, we encourage you to report it responsibly. **Please do not open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+Use GitHub's built-in private vulnerability reporting to submit your report:
+
+1. Navigate to the **Security** tab of this repository.
+2. Click **"Report a vulnerability"** under **Private vulnerability reporting**.
+3. Fill out the advisory form with as much detail as possible.
+
+Alternatively, you can go directly to:
+
+```
+https://github.com/dbt-labs/dbt-external-tables/security/advisories/new
+```
+
+### What to Include
+
+To help us understand and resolve the issue quickly, please include:
+
+- A description of the vulnerability and its potential impact.
+- Step-by-step instructions to reproduce the issue.
+- The affected version(s) of the project.
+- Any relevant logs, screenshots, or proof-of-concept code.
+- Your suggested severity (Critical, High, Medium, Low) if you have one.
+
+Because dbt-external-tables generates SQL statements and handles database connection parameters, please pay special attention to:
+
+- SQL injection vectors through external table definitions or source configurations.
+- Credential exposure through logging or error messages.
+- Path traversal in file location parameters.
+
+### What to Expect
+
+- **Acknowledgment:** We will acknowledge receipt of your report within **3 business days**.
+- **Updates:** We will provide status updates as we investigate, typically within **10 business days**.
+- **Resolution:** Once a fix is ready, we will coordinate disclosure with you before making any public announcement.
+
+### Scope
+
+This policy applies to the latest supported release of this project. If you are unsure whether a version is still supported, please include the version details in your report and we will let you know.
+
+### Guidelines
+
+We ask that you:
+
+- Give us a reasonable amount of time to address the issue before making any public disclosure.
+- Make a good-faith effort to avoid disrupting the project, its infrastructure, or its users during your research.
+- Do not access, modify, or delete data that does not belong to you.
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | Yes       |
+
+For questions about which versions are actively maintained, please refer to the project's release documentation.
+
+## Thank You
+
+We appreciate the security research community's efforts in helping keep dbt Labs and our users safe. Responsible disclosure makes the open-source ecosystem stronger for everyone.
+
+For urgent or critical issues, please reach out to the [dbt Labs Security Team](mailto:security+ghreport@dbtlabs.com).

--- a/macros/common/stage_external_sources.sql
+++ b/macros/common/stage_external_sources.sql
@@ -33,7 +33,7 @@
         
     {% endfor %}
     
-    {% if sources_to_stage|length == 0 %}
+    {% if sources_to_stage|length == 0 and execute %}
         {% do log('No external sources selected', info = true) %}
     {% endif %}
             

--- a/macros/plugins/fabric/create_external_table.sql
+++ b/macros/plugins/fabric/create_external_table.sql
@@ -9,7 +9,7 @@
     create external table {{source(source_node.source_name, source_node.name)}} (
         {% for column in columns %}
             {# TODO set nullity based on schema tests?? #}
-            {%- set nullity = 'NOT NULL' if 'not_null' in columns.tests else 'NULL'-%}
+            {%- set nullity = 'NOT NULL' if 'not_null' in column.tests else 'NULL'-%}
             {{adapter.quote(column.name)}} {{column.data_type}} {{nullity}}
             {{- ',' if not loop.last -}}
         {% endfor %}


### PR DESCRIPTION
## Summary

- **Fabric nullity bug (fixes #407):** In `macros/plugins/fabric/create_external_table.sql`, the nullity check referenced `columns.tests` (the entire collection) instead of `column.tests` (the loop variable). This caused every column to receive the same `NOT NULL`/`NULL` setting regardless of individual test configuration. Fixed by changing `columns.tests` to `column.tests`.

- **False log during compile (fixes #310):** In `macros/common/stage_external_sources.sql`, the "No external sources selected" log message fired during `dbt compile` because `execute` is `false` at compile time, but the log had no `execute` guard. Added `and execute` to the condition so the message only appears during actual execution.

- **SECURITY.md:** Added a security policy based on the dbt-labs org-level template, with additional guidance specific to this package's SQL generation and database connection handling.

## Changes

| File | Change |
|------|--------|
| `macros/plugins/fabric/create_external_table.sql` | `columns.tests` -> `column.tests` |
| `macros/common/stage_external_sources.sql` | Added `and execute` guard to log condition |
| `SECURITY.md` | New file |

## Test plan

- [ ] Verify Fabric external table creation applies per-column nullity correctly when only some columns have `not_null` tests
- [ ] Verify `dbt compile` no longer emits "No external sources selected" when external sources are configured
- [ ] Verify `dbt run-operation stage_external_sources` still emits the message when genuinely no sources are selected